### PR TITLE
stop double escaping on home page

### DIFF
--- a/public/locales/en/home.json
+++ b/public/locales/en/home.json
@@ -6,7 +6,7 @@
 			"string3": "enterprise software"
 		},
 		"description": {
-			"string1": "The Rocky Enterprise Software Foundation&apos;s vision is to create and nurture a community of individuals and organizations that are committed to ensuring that longevity, stewardship, and innovation of enterprise grade/class open-source software that is always freely available.",
+			"string1": "The Rocky Enterprise Software Foundation's vision is to create and nurture a community of individuals and organizations that are committed to ensuring that longevity, stewardship, and innovation of enterprise grade/class open-source software that is always freely available.",
 			"string2": "We invite all individuals and organizations who believe in this vision to stand with us and be a part of the Foundation and Projects."
 		},
 		"cta": "Join Us",


### PR DESCRIPTION
It seems like escaping html entities in is not neccessary in this case

![image](https://github.com/resf/resf.org/assets/13542760/2e04adea-2c1f-444a-a34b-64296a526fb0)
