### PR TITLE
Fix: Update FAQ links and add IDs for disclosure sections

### DIFF
--- a/config/faq.ts
+++ b/config/faq.ts
@@ -134,7 +134,7 @@ export const byLaws = [
   {
     slug: "where-can-read",
     question: "Where can I read the RESF bylaws and charter?",
-    answer: `You can read the bylaws <a href="https://www.resf.org/about#bylaws">here</a> and the charter <a href="https://www.resf.org/about#charter">here</a>.
+    answer: `You can read the bylaws <a href="/about#bylaws">here</a> and the charter <a href="/about#charter">here</a>.
     `,
   },
 ];

--- a/config/faq.ts
+++ b/config/faq.ts
@@ -134,7 +134,7 @@ export const byLaws = [
   {
     slug: "where-can-read",
     question: "Where can I read the RESF bylaws and charter?",
-    answer: `You can read them <a href="https://rockylinux.org/bylaws-charter">here</a>.
+    answer: `You can read the bylaws <a href="https://www.resf.org/about#bylaws">here</a> and the charter <a href="https://www.resf.org/about#charter">here</a>.
     `,
   },
 ];

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -152,7 +152,7 @@ const About: NextPage = ({ menuItems }: AboutProps) => {
                     )}
                   </Disclosure>
 
-                  <Disclosure as="div" className="pt-6">
+                  <Disclosure as="div" id="charter" className="pt-6">
                     {({ open }) => (
                       <>
                         <dt>
@@ -182,7 +182,7 @@ const About: NextPage = ({ menuItems }: AboutProps) => {
                     )}
                   </Disclosure>
 
-                  <Disclosure as="div" className="pt-6">
+                  <Disclosure as="div" id="bylaws" className="pt-6">
                     {({ open }) => (
                       <>
                         <dt>


### PR DESCRIPTION
This pull request updates the FAQ and About page to improve access to the RESF bylaws and charter. The changes clarify links in the FAQ and add anchor IDs to relevant sections on the About page to enable direct linking.

Content updates:

* Updated the FAQ answer in `config/faq.ts` to provide separate, direct links to the bylaws and charter on the RESF website.

Accessibility and navigation improvements:

* Added `id="charter"` to the charter section and `id="bylaws"` to the bylaws section in `pages/about.tsx`, allowing users to link directly to these sections. [[1]](diffhunk://#diff-3294a6926036cb23180c3356148151e8b69a308295566afc57dea367ca9b896eL155-R155) [[2]](diffhunk://#diff-3294a6926036cb23180c3356148151e8b69a308295566afc57dea367ca9b896eL185-R185)